### PR TITLE
svg-spritemap-webpack-pluginを正常動作するバージョン以下に固定する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -866,10 +866,10 @@
       "integrity": "sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q==",
       "dev": true
     },
-    "@hapi/formula": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-1.2.0.tgz",
-      "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA==",
+    "@hapi/bourne": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
+      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
       "dev": true
     },
     "@hapi/hoek": {
@@ -879,23 +879,16 @@
       "dev": true
     },
     "@hapi/joi": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.7.tgz",
-      "integrity": "sha512-anaIgnZhNooG3LJLrTFzgGALTiO97zRA1UkvQHm9KxxoSiIzCozB3RCNCpDnfhTJD72QlrHA8nwGmNgpFFCIeg==",
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
+      "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
       "dev": true,
       "requires": {
-        "@hapi/address": "^2.1.2",
-        "@hapi/formula": "^1.2.0",
-        "@hapi/hoek": "^8.2.4",
-        "@hapi/pinpoint": "^1.0.2",
-        "@hapi/topo": "^3.1.3"
+        "@hapi/address": "2.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/topo": "3.x.x"
       }
-    },
-    "@hapi/pinpoint": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-1.0.2.tgz",
-      "integrity": "sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ==",
-      "dev": true
     },
     "@hapi/topo": {
       "version": "3.1.6",
@@ -9416,9 +9409,9 @@
       "dev": true
     },
     "object-inspect": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
       "dev": true
     },
     "object-is": {
@@ -13268,29 +13261,22 @@
         "has-flag": "^3.0.0"
       }
     },
-    "svg-element-attributes": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/svg-element-attributes/-/svg-element-attributes-1.3.0.tgz",
-      "integrity": "sha512-M4rTTZ186MY4/d3a4XNNuEptXOTIz5qeasp2D7gWVwIDa9e2wF1ccrFs9x7ZW6Sp4+ebCOt9GMCpccC3wt3srg==",
-      "dev": true
-    },
     "svg-spritemap-webpack-plugin": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/svg-spritemap-webpack-plugin/-/svg-spritemap-webpack-plugin-3.5.1.tgz",
-      "integrity": "sha512-FkjgXARo+KgnAkcoG3Q5qY1Xr1Q7mU1rAFTM/wgG/x7VI2S8VGJeS2+fufCzbYs1ARikMTbNJJ4oOr+j3XyTlg==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/svg-spritemap-webpack-plugin/-/svg-spritemap-webpack-plugin-3.3.5.tgz",
+      "integrity": "sha512-IVojln2CNL+yaXsiIY/nO4fl+69+5sZjiTRdvjYy+TeP/p7OnxZu8ZU8aB6rQ7CuLmUYJUqmfu4Zhs8tjB/WJw==",
       "dev": true,
       "requires": {
-        "@hapi/joi": "^16.1.7",
-        "glob": "^7.1.6",
+        "@hapi/joi": "^15.0.3",
+        "glob": "^7.1.4",
         "html4-id": "^1.0.0",
         "loader-utils": "^1.2.3",
-        "mini-svg-data-uri": "^1.1.3",
+        "mini-svg-data-uri": "^1.0.3",
         "mkdirp": "^0.5.1",
-        "svg-element-attributes": "^1.3.0",
         "svg4everybody": "^2.1.9",
-        "svgo": "^1.3.2",
-        "webpack-merge": "^4.2.2",
-        "webpack-sources": "^1.4.3",
+        "svgo": "^1.2.2",
+        "webpack-merge": "^4.2.1",
+        "webpack-sources": "^1.3.0",
         "xmldom": "^0.1.27"
       }
     },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "stylelint-config-recommended": "^2.2.0",
     "stylelint-scss": "^3.6.1",
     "stylelint-webpack-plugin": "^0.10.5",
-    "svg-spritemap-webpack-plugin": "^3.3.1",
+    "svg-spritemap-webpack-plugin": "<=3.3.5",
     "vue-template-compiler": "^2.6.10"
   },
   "repository": {


### PR DESCRIPTION
3.5まで上げると、大元spriteを隠すためのclassが、sprite内のSVGにまで付加されてしまう。
おそらくsvg-spritemap-webpack-pluginのバグ。
それらしい箇所をいじってるコミットがある。
Issue出す。

解決まで、正常動作するバージョンに固定。