### PR TITLE
sprite.svgをサーバールートから読み込む

### DIFF
--- a/wp/wp-content/themes/input-theme-name/index.php
+++ b/wp/wp-content/themes/input-theme-name/index.php
@@ -13,7 +13,7 @@
   >
 </head>
 <body>
-  <?php echo file_get_contents(get_stylesheet_directory() . '/assets/svg/sprite.svg'); ?>
+  <?php echo file_get_contents(dirname(__FILE__) . '/assets/svg/sprite.svg'); ?>
   <div class="js-target">
     <h1>Laravel Mix Boilerplate for WordPress</h1>
     <ul>


### PR DESCRIPTION
https経由だと、BASIC認証かかってるとファイルを読みにいけないので
サーバールートからファイルを読み込むように修正